### PR TITLE
Fixed a url-http-create-request error encoding the message

### DIFF
--- a/lodgeit.el
+++ b/lodgeit.el
@@ -74,7 +74,7 @@
 The MESSAGE must be a JSON encoded string."
   (let ((url-request-method "POST")
 	(url-request-extra-headers '(("Content-Type" . "application/json")))
-	(url-request-data message)
+	(url-request-data (encode-coding-string message 'utf-8))
 	(paste-url (format "%s/json/?method=pastes.newPaste" lodgeit-pastebin-base)))
     (url-retrieve paste-url 'lodgeit-new-paste-handler)))
 


### PR DESCRIPTION
When you had some accents in the message, an error from the 'url-http-create-request'
function occurred. When you encode the message in utf-8, that fixes the issue.

close #2 